### PR TITLE
Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.1.0] - 2017-10-10
+- Improved `syntax` command to correctly color across multiple lines. Solves https://github.com/kylebarron/language-stata/issues/19
+- Colors extended macro functions inside local macros as well as during macro instantiation.
+- Allow macros in `forvalues` loop statement, like ``forval i = `start_num' / `end_num' {``
+- Allow for local and global macros within regular expression match strings
+- Color `_all` as a constant
+- Include Mata functions from old [atom-language-stata](https://github.com/benwhalley/atom-language-stata) package 
+- `drop` and `keep` alert you if you type `drop varlist if` or `drop varlist in`. (It's only legal to use `if` or `in` without a _varlist_).
+
 ## [1.0.4] - 2017-10-02
 - Fix highlighting for global macro with braces inside loop
 - Now the `}` line can only be colored as error if there's text on that line and if there's at least one space before the `}`. 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This package highlights:
 - System commands, functions, and function arguments
 - Macros, both global and local
     - Accurately colors nested macros and escaped macros in strings when you want the inner macro to evaluate at runtime
+    - Colors macro extended functions inside `` `: ... '`` as well as after `local lname:`
 - Regular expressions
     - Colors both the limited syntax provided through the `regexr()` and `regexm()` functions, as well as the vastly expanded regex syntax provided in Stata 14 and 15 through the `ustrregexm()`, `ustrregexrf()`, and `ustrregexra()` functions.
 

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -429,37 +429,30 @@
         'name': 'keyword.functions.data.stata' 
       '3': 
         'name': 'keyword.functions.data.stata' 
-  } 
-  { 
-    'match': 
-      '\\b(drop|keep)\\s+((if)\\s+(.+)\\s+(in)|(in)\\s+(.+)\\s+(if)|(if)|(in))?' 
-    'captures': 
-      '1': 
-        'name': 'keyword.functions.data.stata' 
-      '3': 
-        'name': 'keyword.functions.data.stata' 
-      '4': 
-        'patterns': [ 
-          { 
-            'include': '$self' 
-          } 
-        ] 
-      '5': 
-        'name': 'keyword.functions.data.stata' 
-      '6': 
-        'name': 'keyword.functions.data.stata' 
-      '7': 
-        'patterns': [ 
-          { 
-            'include': '$self' 
-          } 
-        ] 
-      '8': 
-        'name': 'keyword.functions.data.stata' 
-      '9': 
-        'name': 'keyword.functions.data.stata' 
-      '10': 
-        'name': 'keyword.functions.data.stata' 
+  }
+  {
+    'begin': '\\b(drop|keep)\\s+(?!if|in)'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.functions.data.stata'
+    'end': '\\n'
+    'patterns': [
+      {
+        'match': '\\b(if|in)\\b'
+        'name': 'invalid.illegal.name.stata'
+      }
+      {
+        'include': '#comments'
+      }
+    ]
+  }
+  {
+    'match': '\\b(drop|keep)\\s+(if|in)'
+    'captures':
+      '1':
+        'name': 'keyword.functions.data.stata'
+      '2':
+        'name': 'keyword.functions.data.stata'
   }
   {
     'begin': '^\\s*mata:?\\s*$'

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -714,6 +714,53 @@
   'macro-commands':
     'patterns': [
       {
+        'begin': '\\b(loc(a|al)?|gl(o|ob|oba|obal)?)\\s+([a-zA-Z0-9_\'`\\$\\(\\)\\{\\}]+)\\s*(?=:|=)'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.macro.stata'
+          '4':
+            'patterns': [
+              {
+                'match': '[A-Za-z_][A-Za-z0-9_]{0,31}'
+                'name': 'entity.name.type.class.stata'
+              }
+              {
+                'include': '#macro-local'
+              }
+              {
+                'include': '#macro-global'
+              }
+            ]
+            'name': 'entity.name.type.class.stata'
+        'end': '\\n'
+        'patterns': [
+          {
+            'begin': '='
+            'beginCaptures':
+              '0':
+                'name': 'keyword.operator.arithmetic.stata'
+            'end': '(?=\\n)'
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+          }
+          {
+            'begin': ':'
+            'beginCaptures':
+              '0':
+                'name': 'keyword.operator.arithmetic.stata'
+            'end': '(?=\\n)'
+            'patterns': [
+              {
+                'include': '#macro-extended-functions'
+              }
+            ]
+          }          
+        ]
+      }
+      {
         'begin': '\\b(gl(o|ob|oba|obal)?)\\s+(?=[a-zA-Z_`\\$])'
         'beginCaptures':
           '1':
@@ -808,6 +855,109 @@
         ]
       }
     ]
+  'macro-extended-functions':
+    'patterns': [
+      {
+        'include': '#comments'
+      }
+      {
+        'match': '\\b(properties)\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(t(y|yp|ype)?|f(o|or|orm|orma|ormat)?|val(u|ue)?\\s+l(a|ab|abl|able)?|var(i|ia|iab|iabl|iable)?\\s+l(a|ab|abl|able)?|data\\s+l(a|ab|abl|able)?|sort(e|ed|edb|edby)?|lab(e|el)?|maxlength|constraint|char)\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(permname)\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(adosubdir|dir|files?|dirs?|other|sysdir)\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(env(i|ir|iro|iron|ironm|ironme|ironmen|ironment)?)\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(all\\s+(globals|scalars|matrices)|((numeric|string)\\s+scalars))\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(di(s|sp|spl|spla|splay)?)\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(list)\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(rown(a|am|ame|ames)?|coln(a|am|ame|ames)?|rowf(u|ul|ull|ulln|ullna|ullnam|ullname|ullnames)?|colf(u|ul|ull|ulln|ullna|ullnam|ullname|ullnames)?|roweq?|coleq?|rownumb|colnumb|roweqnumb|coleqnumb|rownfreeparms|colnfreeparms|rownlfs|colnlfs|rowsof|colsof|rowvarlist|colvarlist|rowlfnames|collfnames)\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(tsnorm)\\b'
+        'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b((copy|(u|ud)?strlen)\\s+(loc(a|al)?|gl(o|ob|oba|obal)?))\\s+([^\']+)'
+        'captures':
+          '1':
+            'name': 'keyword.macro.extendedfcn.stata'
+          '7':
+            'patterns': [
+              {
+                'include': '#macro-local'
+              }
+              {
+                'include': '#macro-global'
+              }
+              {
+                'match': '.'
+                'name': 'entity.name.type.class.stata'
+              }
+            ]
+      }
+      {
+        'match': '\\b(word\\s+count)'
+        'captures':
+          '1':
+            'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '(word|piece)\\s+([\\s0-9]+)\\s+(of)'
+        'captures':
+          '1':
+            'name': 'keyword.macro.extendedfcn.stata'
+          '2':
+            'name': 'constant.numeric.integer.stata'
+          '3':
+            'name': 'keyword.macro.extendedfcn.stata'
+      }
+      {
+        'match': '\\b(subinstr\\s+(loc(a|al)?|gl(o|ob|oba|obal)?))\\s+([^\']+)'
+        'captures':
+          '1':
+            'name': 'keyword.macro.extendedfcn.stata'
+          '5':
+            'patterns': [
+              {
+                'include': '#macro-local'
+              }
+              {
+                'include': '#macro-global'
+              }
+              {
+                'include': '#string-regular'
+              }
+              {
+                'match': '.'
+                'name': 'entity.name.type.class.stata'
+              }
+            ]
+      }
+    ]
   'macro-local-escaped':
     'patterns': [
       {
@@ -837,6 +987,53 @@
   'macro-local':
     'patterns': [
       {
+        'begin': '(`)(=)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.string.begin.stata'
+          '2':
+            'name': 'keyword.operator.comparison.stata'
+        'end': '\''
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.blahblah.string.end.stata'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
+        'begin': '(`)(:)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.string.begin.stata'
+          '2':
+            'name': 'keyword.operator.comparison.stata'
+        'end': '\''
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.blahblah.string.end.stata'
+        'contentName': 'meta.macro-extended-function.stata'
+        'patterns': [
+          {
+            'include': '#macro-local'
+          }
+          {
+            'include': '#macro-extended-functions'
+          }
+          {
+            'include': '#constants'
+          }
+          {
+            'include': '#string-compound'
+          }
+          {
+            'include': '#string-regular'
+          }
+        ]
+      }
+      {
         'begin': '`(?!")'
         'beginCaptures':
           '0':
@@ -846,6 +1043,10 @@
           '0':
             'name': 'punctuation.definition.string.end.stata'
         'patterns': [
+          {
+            'match': '\\+\\+|\\-\\-'
+            'name': 'keyword.operator.arithmetic.stata'
+          }
           {
             'include': '#macro-local'
           }
@@ -1061,7 +1262,7 @@
   'string-regular':
     'patterns': [
       {
-        'begin': '"'
+        'begin': '(?<!`)"'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.stata'

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -24,7 +24,7 @@
     'include': '#comments'
   }
   {
-    'include': '#numbers'
+    'include': '#constants'
   }
   {
     'include': '#operators'
@@ -135,7 +135,7 @@
       '3':
         'patterns': [
           {
-            'include': '#numbers'
+            'include': '#constants'
           }
           {
             'match': 'm|n'
@@ -147,7 +147,7 @@
       '5':
         'patterns': [
           {
-            'include': '#numbers'
+            'include': '#constants'
           }
           {
             'match': 'm|n'
@@ -218,7 +218,7 @@
       '2':
         'patterns': [
           {
-            'include': '#numbers'
+            'include': '#constants'
           }
           {
             'include': '#operators'
@@ -598,7 +598,7 @@
             'name': 'punctuation.definition.parameters.end.stata'
         'patterns': [
           {
-            'include': '#numbers'
+            'include': '#constants'
           }
           {
             'match': '(\\{|\\})'
@@ -900,7 +900,7 @@
         ]
       }
     ]
-  'numbers':
+  'constants':
     'patterns': [
       {
         'match': '\\b(?i:(\\d+\\.\\d*(e[\\-\\+]?\\d+)?))(?=[^a-zA-Z_])'
@@ -1074,16 +1074,9 @@
             'include': '#operators'
           }
           {
-            'include': '#numbers'
+            'include': '#constants'
           }
         ]
-      }
-    ]
-  'generic_names':
-    'patterns': [
-      {
-        'comment': 'this currently doesn\'t do anything'
-        'match': '[A-Za-z_][A-Za-z0-9_]{0,31}'
       }
     ]
   'reserved_names':
@@ -1518,7 +1511,7 @@
           '9':
             'patterns': [
               {
-                'include': '#numbers'
+                'include': '#constants'
               }
               {
                 'match': ','
@@ -1580,7 +1573,7 @@
           '8':
             'patterns': [
               {
-                'include': '#numbers'
+                'include': '#constants'
               }
               {
                 'match': ','
@@ -1666,7 +1659,7 @@
                 'include': '#comments-triple-slash'
               }          
               {
-                'include': '#numbers'
+                'include': '#constants'
               }
             ]
           '10':
@@ -1746,7 +1739,7 @@
                 'include': '#comments-triple-slash'
               }          
               {
-                'include': '#numbers'
+                'include': '#constants'
               }
             ]
           '9':

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -860,9 +860,9 @@
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.stata'
-        'end': '(\\})'
+        'end': '\\}'
         'endCaptures':
-          '1':
+          '0':
             'name': 'punctuation.definition.string.end.stata'
         'patterns': [
           {
@@ -878,11 +878,11 @@
         ]
       }
       {
-        'begin': '(\\$)'
+        'begin': '\\$'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.stata'
-        'end': '(?=\\"|\\s|\\n|/|,)'
+        'end': '(?=\\"|\\s|\\n|/|,|\\$)'
         'endCaptures':
           '1':
             'name': 'punctuation.definition.string.end.stata'
@@ -1374,7 +1374,11 @@
     'patterns': [
       # The following match the insides of a regular expression
       {
-        'match': '\\^|\\$'
+        'match': '\\^'
+        'name': 'keyword.control.anchor.stata'
+      }
+      {
+        'match': '\\$(?![a-zA-Z\\{])'
         'name': 'keyword.control.anchor.stata'
       }
       {
@@ -1402,6 +1406,12 @@
       }
       {
         'include': '#ascii-regex-character-class'
+      }
+      {
+        'include': '#macro-local'
+      }
+      {
+        'include': '#macro-global'
       }
       {
         # 'comment' 'NOTE: Error if I have \.+ No idea why but it works fine it seems with just \.'
@@ -1746,7 +1756,11 @@
   'unicode-regex-internals':
     'patterns': [
       {
-        'match': '\\\\[bBAZzG]|\\^|\\$'
+        'match': '\\\\[bBAZzG]|\\^'
+        'name': 'keyword.control.anchor.stata'
+      }
+      {
+        'match': '\\$(?![a-zA-Z\\{])'
         'name': 'keyword.control.anchor.stata'
       }
       {
@@ -1822,6 +1836,12 @@
       }
       {
         'include': '#unicode-regex-character-class'
+      }
+      {
+        'include': '#macro-local'
+      }
+      {
+        'include': '#macro-global'
       }
       {
         # 'comment' 'NOTE: Error if I have \.+ No idea why but it works fine it seems with just \.'

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -195,7 +195,7 @@
         'include': '#reserved_names'
       }
       {
-        'match': '([A-Za-z_][A-Za-z0-9_]{0,31})'
+        'match': '[A-Za-z_][A-Za-z0-9_]{0,31}'
         'name': 'entity.name.type.class.stata'
       }
       {
@@ -235,7 +235,7 @@
         'include': '#reserved_names'
       }
       {
-        'match': '([A-Za-z_][A-Za-z0-9_]{0,31})'
+        'match': '[A-Za-z_][A-Za-z0-9_]{0,31}'
         'name': 'entity.name.type.class.stata'
       }
       {
@@ -294,7 +294,7 @@
         'include': '#macro-global'
       }
       {
-        'match': '([A-Za-z_][A-Za-z0-9_]{0,31})'
+        'match': '[A-Za-z_][A-Za-z0-9_]{0,31}'
         'name': 'entity.name.function.stata'
       }
       {

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -926,6 +926,10 @@
         'match': '(?<![a-zA-Z0-9])(\\.(?![\\./]))(?![a-zA-Z0-9])'
         'name': 'constant.language.stata'
       }
+      {
+        'match': '_all'
+        'name': 'constant.language.stata'
+      }
     ]
   'operators':
     'patterns': [

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -464,12 +464,37 @@
   {
     'begin': '^\\s*mata:?\\s*$'
     'comment': 'won\'t match single-line Mata statements'
-    'contentName': 'source.mata'
     'end': '^\\s*end\\s*$\\n?'
     'name': 'meta.embedded.block.mata'
     'patterns': [
       {
-        'include': 'source.mata'
+        'match': '(?<![^$\\s])(version|pragma|if|else|for|while|do|break|continue|goto|return)(?=\\s)'
+        'name': 'keyword.control.mata'
+      }
+      {
+        'captures':
+          '1':
+            'name': 'storage.type.eltype.mata'
+          '4':
+            'name': 'storage.type.orgtype.mata'
+        'match': '\\b(transmorphic|string|numeric|real|complex|(pointer(\\([^)]+\\))?))\\s+(matrix|vector|rowvector|colvector|scalar)\\b'
+        'name': 'storage.type.mata'
+      }
+      {
+        'comment': 'need to end with whitespace character here or last group doesn\'t match'
+        'match': '\\b(transmorphic|string|numeric|real|complex|(pointer(\\([^)]+\\))?))\\s'
+        'name': 'storage.type.eltype.mata'
+      }
+      {
+        'match': '\\b(matrix|vector|rowvector|colvector|scalar)\\b'
+        'name': 'storage.type.orgtype.mata'
+      }
+      {
+        'match': '\\!|\\+\\+|\\-\\-|\\&|\\\'|\\?|\\\\|\\:\\:|\\,|\\.\\.|\\||\\=|\\=\\=|\\>\\=|\\<\\=|\\<|\\>|\\!\\=|\\#|\\+|\\-|\\*|\\^|\\/'
+        'name': 'keyword.operator.mata'
+      }
+      {
+        'include': '$self'
       }
     ]
   }

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -48,73 +48,7 @@
     'include': '#subsetting'
   }
   {
-    'begin': '\\b(gl(o|ob|oba|obal)?)\\s+(?=[a-zA-Z_`\\$])'
-    'beginCaptures':
-      '1':
-        'name': 'storage.modifier.macro.test.stata'
-    'end': '(\\})|(?=\\"|\\s|\\n|/|,|=)'
-    'patterns': [
-      {
-        'include': '#reserved_names'
-      }
-      {
-        'match': '([A-Za-z_][A-Za-z0-9_]{0,31})'
-        'name': 'entity.name.type.class.stata'
-      }
-      {
-        'include': '#macro-local'
-      }
-      {
-        'include': '#macro-global'
-      }
-    ]
-  }
-  {
-    'begin': '\\b(loc(a|al)?)\\s+(\\+\\+|\\-\\-)?(?=[a-zA-Z_`\\$])'
-    'beginCaptures':
-      '1':
-        'name': 'storage.modifier.macro.test.stata'
-      '3':
-        'name': 'keyword.operator.arithmetic.stata'
-    'end': '(?=:|\\"|\\s|\\n|/|,|=)'
-    'patterns': [
-      {
-        'match': '[^a-zA-Z0-9_\'`\\$\\(\\)]'
-        'name': 'invalid.illegal.name.stata'
-      }
-      {
-        'match': '([A-Za-z_][A-Za-z0-9_]{0,31})'
-        'name': 'entity.name.type.class.stata'
-      }
-      {
-        'include': '#macro-local'
-      }
-      {
-        'include': '#macro-global'
-      }
-    ]
-  }
-  {
-    'begin': '\\b(tempvar|tempname|tempfile)\\s+(?=[a-zA-Z_`\\$])'
-    'beginCaptures':
-      '1':
-        'name': 'storage.modifier.macro.test.stata'
-    'end': '(?=\\"|\\s|\\n|/|,)'
-    'patterns': [
-      {
-        'include': '#reserved_names'
-      }
-      {
-        'match': '([A-Za-z_][A-Za-z0-9_]{0,31})'
-        'name': 'entity.name.type.class.stata'
-      }
-      {
-        'include': '#macro-local'
-      }
-      {
-        'include': '#macro-global'
-      }
-    ]
+    'include': '#macro-commands'
   }
   {
     'comment': 'keywords that delimit flow conditionals'
@@ -775,6 +709,103 @@
         'captures':
           '1':
             'name': 'keyword.docblockr.stata'
+      }
+    ]
+  'macro-commands':
+    'patterns': [
+      {
+        'begin': '\\b(gl(o|ob|oba|obal)?)\\s+(?=[a-zA-Z_`\\$])'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.macro.stata'
+        'end': '(\\})|(?=\\"|\\s|\\n|/|,|=)'
+        'patterns': [
+          {
+            'include': '#reserved_names'
+          }
+          {
+            'match': '[A-Za-z_][A-Za-z0-9_]{0,31}'
+            'name': 'entity.name.type.class.stata'
+          }
+          {
+            'include': '#macro-local'
+          }
+          {
+            'include': '#macro-global'
+          }
+        ]
+      }
+      {
+        'begin': '\\b(loc(a|al)?)\\s+(\\+\\+|\\-\\-)?(?=[a-zA-Z_`\\$])'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.macro.stata'
+          '3':
+            'name': 'keyword.operator.arithmetic.stata'
+        'end': '(?=\\"|\\s|\\n|/|,|=)'
+        'patterns': [
+          {
+            'match': '[^a-zA-Z0-9_\'`\\$\\(\\)]'
+            'name': 'invalid.illegal.name.stata'
+          }
+          {
+            'match': '[A-Za-z_][A-Za-z0-9_]{0,31}'
+            'name': 'entity.name.type.class.stata'
+          }
+          {
+            'include': '#macro-local'
+          }
+          {
+            'include': '#macro-global'
+          }
+        ]
+      }
+      {
+        'begin': '\\b(tempvar|tempname|tempfile)\\s+(?=[a-zA-Z_`\\$])'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.macro.stata'
+        'end': '(?=\\"|\\s|\\n|/|,)'
+        'patterns': [
+          {
+            'include': '#reserved_names'
+          }
+          {
+            'match': '[A-Za-z_][A-Za-z0-9_]{0,31}'
+            'name': 'entity.name.type.class.stata'
+          }
+          {
+            'include': '#macro-local'
+          }
+          {
+            'include': '#macro-global'
+          }
+        ]
+      }
+      {
+        'begin': '\\b(ma(c|cr|cro)?)\\s+(drop|l(i|is|ist)?)'
+        'beginCaptures':
+          '0':
+            'name': 'keyword.macro.stata'
+        'end': '(?=\\n)'
+        'patterns': [
+          {
+            'include': '#constants'
+          }
+          {
+            'include': '#macro-global'
+          }
+          {
+            'include': '#macro-local'
+          }
+          {
+            'include': '#comments'
+          }
+          {
+            'match': '[A-Za-z_][A-Za-z0-9_]{0,31}'
+            'name': 'entity.name.type.class.stata'
+          }
+        ]
       }
     ]
   'macro-local-escaped':


### PR DESCRIPTION
Updates
- Colors extended macro functions inside local macros as well as during macro instantiation.
- Allow for local and global macros within regular expression match strings
- Color `_all` as a constant
- Include Mata functions from old [atom-language-stata](https://github.com/benwhalley/atom-language-stata) package 
- `drop` and `keep` alert you if you type `drop varlist if` or `drop varlist in`. (It's only legal to use `if` or `in` without a _varlist_).