### PR TITLE
allow /* to start a comment block anywhere, not just after whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.2.5] - 2017-11-18
+- allow /* to start a comment block anywhere, not just after whitespace. Fixes https://github.com/kylebarron/language-stata/issues/55
+
 ## [1.2.4] - 2017-11-18
 - Fix `gen` command
 - Fix global macro coloring when using `\` as a path delimiter in strings. (i.e. `"$datadir\file.dta"`). Fixes [#52](https://github.com/kylebarron/language-stata/issues/52).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub forks](https://img.shields.io/github/forks/kylebarron/language-stata.svg?style=social&label=Fork)](https://github.com/kylebarron/language-stata)
 
 ## News:
-The [stata-exec](https://atom.io/packages/stata-exec) package has been updated and now makes it extremely easy to run code in Stata on macOS.
+The [stata-exec](https://atom.io/packages/stata-exec) package has been updated and now makes it extremely easy to run code line-by-line in Stata on macOS.
 
 Also [available for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=kylebarron.stata-enhanced).
 

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -688,8 +688,7 @@
   'comments-block':
     'patterns': [
       {
-        'comment': 'There could be a * as a glob in a path'
-        'begin': '^/\\*|(?<=\\s)/\\*'
+        'begin': '/\\*'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.comment.begin.stata'


### PR DESCRIPTION
Fixes https://github.com/kylebarron/language-stata/issues/55