### PR TITLE
allow there to be no spaces before = in gen command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.2.6] - 2017-11-20
+- allow there to be no spaces before = in gen command. Fixes https://github.com/kylebarron/language-stata/issues/59.
+
 ## [1.2.5] - 2017-11-18
 - allow /* to start a comment block anywhere, not just after whitespace. Fixes https://github.com/kylebarron/language-stata/issues/55
 

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -446,7 +446,7 @@
   }
   {
     'match':
-      '\\b(g(enerate|enerat|enera|ener|ene|en|e)?|egen)\\s+((byte|int|long|float|double|str[1-9]?[0-9]?[0-9]?[0-9]?|strL)\\s+)?([^=\\s]+)\\s+((==)|(=))'
+      '\\b(g(enerate|enerat|enera|ener|ene|en|e)?|egen)\\s+((byte|int|long|float|double|str[1-9]?[0-9]?[0-9]?[0-9]?|strL)\\s+)?([^=\\s]+)\\s*((==)|(=))'
     'captures':
       '1':
         'name': 'keyword.functions.data.stata'


### PR DESCRIPTION
 Fixes https://github.com/kylebarron/language-stata/issues/55