### PR TITLE
Update syntax command

### DIFF
--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -346,7 +346,25 @@
             'name': 'entity.name.type.class.stata'
           }
           {
-            'include': '$self'
+            'include': '#constants'
+          }
+          {
+            'include': '#operators'
+          }
+          {
+            'include': '#string-compound'
+          }
+          {
+            'include': '#string-regular'
+          }
+          {
+            'include': '#macro-local'
+          }
+          {
+            'include': '#macro-global'
+          }
+          {
+            'include': '#builtin_variables'
           }
         ]
       }
@@ -399,7 +417,25 @@
                     'name': 'support.type.stata'
               }
               {
-                'include': '$self'
+                'include': '#constants'
+              }
+              {
+                'include': '#operators'
+              }
+              {
+                'include': '#string-compound'
+              }
+              {
+                'include': '#string-regular'
+              }
+              {
+                'include': '#macro-local'
+              }
+              {
+                'include': '#macro-global'
+              }
+              {
+                'include': '#builtin_variables'
               }
             ]
           }
@@ -409,7 +445,25 @@
             'name': 'entity.name.type.class.stata'
           }
           {
-            'include': '$self'
+            'include': '#constants'
+          }
+          {
+            'include': '#operators'
+          }
+          {
+            'include': '#string-compound'
+          }
+          {
+            'include': '#string-regular'
+          }
+          {
+            'include': '#macro-local'
+          }
+          {
+            'include': '#macro-global'
+          }
+          {
+            'include': '#builtin_variables'
           }
         ]
       }

--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -342,8 +342,24 @@
             'name': 'punctuation.definition.parameters.end.stata'
           }
           {
-            'match': 'varlist|varname|newvarlist|newvarname|namelist|name|anything|if|in|using|exp|fweight|aweight|pweight|iweight'
+            'match': '\\b(varlist|varname|newvarlist|newvarname|namelist|name|anything)\\b'
             'name': 'entity.name.type.class.stata'
+          }
+          {
+            'match': '\\b((if|in|using|fweight|aweight|pweight|iweight))\\b(/)?'
+            'captures':
+              '2':
+                'name': 'entity.name.type.class.stata'
+              '3':
+                'name': 'keyword.operator.arithmetic.stata'
+          }
+          {
+            'match': '(/)?(exp)'
+            'captures':
+              '1':
+                'name': 'keyword.operator.arithmetic.stata'
+              '2':
+                'name': 'entity.name.type.class.stata'
           }
           {
             'include': '#constants'
@@ -411,7 +427,7 @@
             'patterns': [
               {
                 'comment': 'the first word is often a type'
-                'match': 'integer|intege|integ|inte|int|real|string|strin|stri|str'
+                'match': '\\b(integer|intege|integ|inte|int|real|string|strin|stri|str)\\b'
                 'captures':
                   '0':
                     'name': 'support.type.stata'


### PR DESCRIPTION
- Color `*` in syntax command as operator when it comes at the beginning of the line (when splitting `syntax` over multiple lines)
- Color `/` in syntax command

Fixes https://github.com/kylebarron/language-stata/issues/63