### PR TITLE
basic stata-webdoc language and snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ on the command line using [Pandoc](https://pandoc.org/).
 
 The file [`dyntext.dotex`](examples/dyntext.dotex) is a proof-of-concept and should compile with LaTeX but the output is not shown here.
 
+### Webdoc support
+
+If you use the user-created command
+[webdoc](http://repec.sowi.unibe.ch/stata/webdoc/getting-started.html), you can
+add highlighting by using a `.dowd` file extension or by manually selecting the
+language of the current file to be "Stata Webdoc".
+
+
 #### Footnotes
 
 <a name="myfootnote1">1</a>: The following code is legal Stata code, but Atom will confuse the `*` used as multiplication with the `*` used for a comment. So if your cursor is on the second line and you press <kbd>ctrl</kbd>+<kbd>/</kbd>, Atom will remove the `*` symbol and the semantic meaning of the multiplication will be lost. Thus using `// ` as the comment symbol is safer.

--- a/grammars/stata-webdoc.cson
+++ b/grammars/stata-webdoc.cson
@@ -1,10 +1,8 @@
 'scopeName': 'source.webdoc.stata'
 'name': 'Stata Webdoc'
 'fileTypes': [
-  'do'
   'dowd'
 ]
-'firstLineMatch': 'webdoc init'
 'patterns': [
   {
     'begin': '(/\\*\\*\\*)(\\s)'

--- a/grammars/stata-webdoc.cson
+++ b/grammars/stata-webdoc.cson
@@ -16,7 +16,7 @@
     'name': 'meta.tag.block.$2.html'
     'patterns': [
       {
-        'include': 'text.html.basic'
+        'include': 'text.md'
       }
     ]
   }

--- a/grammars/stata-webdoc.cson
+++ b/grammars/stata-webdoc.cson
@@ -1,0 +1,32 @@
+'scopeName': 'source.webdoc.stata'
+'name': 'Stata Webdoc'
+'fileTypes': [
+  'do'
+  'dowd'
+]
+'firstLineMatch': 'webdoc init'
+'patterns': [
+  {
+    'begin': '(/\\*\\*\\*)(\\s)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.comment.webdoc.stata'
+    'end': '(^|\\s)(\\*\\*\\*/)'
+    'endCaptures':
+      '2':
+        'name': 'punctuation.definition.comment.webdoc.stata'
+    'name': 'meta.tag.block.$2.html'
+    'patterns': [
+      {
+        'include': 'text.html.basic'
+      }
+    ]
+  }
+  {
+    'match': 'webdoc|stlog'
+    'name': 'support.function.custom.stata'
+  }
+  {
+    'include': 'source.stata'
+  }
+]

--- a/keymaps/stata-dyndoc.cson
+++ b/keymaps/stata-dyndoc.cson
@@ -13,3 +13,19 @@
   '~': 'markdown:strike-through'
   '@': 'markdown:link'
   '!': 'markdown:image'
+
+'.platform-darwin atom-text-editor[data-grammar="source webdoc stata"]':
+  'cmd-shift-x': 'markdown:toggle-task'
+'.platform-win32 atom-text-editor[data-grammar="source webdoc stata"]':
+  'ctrl-shift-x': 'markdown:toggle-task'
+'.platform-linux atom-text-editor[data-grammar="source webdoc stata"]':
+  'ctrl-shift-x': 'markdown:toggle-task'
+
+'atom-text-editor[data-grammar="source webdoc stata"]':
+  'tab': 'markdown:indent-list-item'
+  'shift-tab': 'markdown:outdent-list-item'
+  '_': 'markdown:emphasis'
+  '*': 'markdown:strong-emphasis'
+  '~': 'markdown:strike-through'
+  '@': 'markdown:link'
+  '!': 'markdown:image'

--- a/snippets/language-stata.cson
+++ b/snippets/language-stata.cson
@@ -96,7 +96,7 @@
     'body':
       """<<dd_version: ${1:1}>>
       """
-
+'.source.webdoc.stata':
   'Webdoc Enclose':
     'prefix': 'wdenc'
     'body': """
@@ -104,7 +104,6 @@
       $1
       ***/
     """
-    
   'Webdoc Separate':
     'prefix': 'wdsep'
     'body': """
@@ -112,7 +111,6 @@
       $1
       /***
     """
-    
   'Webdoc Stlog cmdstrip':
     'prefix': 'wdstlcmdstrip'
     'body': """
@@ -120,7 +118,6 @@
       $1
       webdoc stlog close
     """
-    
   'Webdoc Stlog':
     'prefix': 'wdstlog'
     'body': """
@@ -128,8 +125,6 @@
       $1
       webdoc stlog close
     """
-    
   'Webdoc Graph SVG':
     'prefix': 'wdgraphsvg'
     'body': 'webdoc graph, as(svg)'	  
-

--- a/snippets/language-stata.cson
+++ b/snippets/language-stata.cson
@@ -96,3 +96,40 @@
     'body':
       """<<dd_version: ${1:1}>>
       """
+
+  'Webdoc Enclose':
+    'prefix': 'wdenc'
+    'body': """
+      /***
+      $1
+      ***/
+    """
+    
+  'Webdoc Separate':
+    'prefix': 'wdsep'
+    'body': """
+      ***/
+      $1
+      /***
+    """
+    
+  'Webdoc Stlog cmdstrip':
+    'prefix': 'wdstlcmdstrip'
+    'body': """
+      webdoc stlog, cmdstrip
+      $1
+      webdoc stlog close
+    """
+    
+  'Webdoc Stlog':
+    'prefix': 'wdstlog'
+    'body': """
+      webdoc stlog
+      $1
+      webdoc stlog close
+    """
+    
+  'Webdoc Graph SVG':
+    'prefix': 'wdgraphsvg'
+    'body': 'webdoc graph, as(svg)'	  
+


### PR DESCRIPTION
I created a very simple additional language to help me with writing webdoc-compatible .do-files. Sharing them in case anyone else might be interested.

`stata-webdoc.cson`: This basic version
- sets everything between '/***' and '***/' to html (which is the webdoc way of differentiating between code and text blocks),
- automatically recognizes documents ending in .dowd, and those ending in .do that have 'webdoc init' on the first line,
- highlights 'webdoc' and 'stlog' as custom function names.

I am unsure about approriate names for the components. They could probably be chosen better.

` snippets/language-stata.cson`: I also included some snippets but this is by no means a polished list.