### PR TITLE
Python syntax highlighting

### DIFF
--- a/grammars/stata.cson
+++ b/grammars/stata.cson
@@ -454,7 +454,17 @@ patterns: [
       }
       {include: '$self'}
     ]
-  }
+  },
+  {
+    "begin": "^\\s*python:?\\s*$",
+    "end": "^\\s*end\\s*$\\n?",
+    "name": "source.python",
+    "patterns":[
+        {
+            "include": "source.python"
+        }
+    ]
+  }, 
   {
     begin: '\\b(odbc)\\b'
     beginCaptures:


### PR DESCRIPTION
Adds Python Syntax highlighting for python code blocks (does not support single-line statements)